### PR TITLE
Add heroku #2

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -23,9 +23,5 @@ test:
 production:
   <<: *default
   #database: db/production.sqlite3
-  adapter: postgresql
-  encoding: unicode
-  database: mydatabase
-  username: <%= ENV['USERNAME'] %>
-  password: <%= ENV['PASSWORD'] %>
-  host: <%= ENV['IP'] %>
+  adapter: pg
+  database: db/production.pg

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,5 +23,9 @@ test:
 production:
   <<: *default
   #database: db/production.sqlite3
-  adapter: pg
-  database: db/production.pg
+  adapter: postgresql
+  encoding: unicode
+  database: mydatabase
+  username: <%= ENV['USERNAME'] %>
+  password: <%= ENV['PASSWORD'] %>
+  host: <%= ENV['IP'] %>


### PR DESCRIPTION
下記により、cloud9のproductionにて実行可能となりました。
・この変更
・https://github.com/Aerogami/guides/wiki/Cloud9-workspace-setup-with-Rails-and-Postgresql
・/app/controllers/connecthookup_controller.rbの65行目expireの型違いの修正（仮で下記なら可）
      data = { \
        :key => key \
        ,:access_token => j["access_token"] \
        ,:refresh_token => j["refresh_token"]
      }